### PR TITLE
add zdoom style multiload command line switch

### DIFF
--- a/engine/h2shared/quakefs.c
+++ b/engine/h2shared/quakefs.c
@@ -1369,9 +1369,6 @@ void FS_Init (void)
 					break;
 			}
 		}
-		//Sys_Error("com_argc %d", com_argc);
-		//Sys_Error(com_argv[i + 3]);
-		Sys_Printf("what\n");
 	}
 }
 


### PR DESCRIPTION
ZDoom-style multi-mod loading command line switch. Example:
glh2.exe -noportals -game fo4d peanut

base paths load first
fo4d loads second
peanut loads last

progs and cfg files from the last to load override previously loaded versions.