### PR TITLE
Add Scriptable Glow FX

### DIFF
--- a/engine/hexen2/cl_parse.c
+++ b/engine/hexen2/cl_parse.c
@@ -250,8 +250,7 @@ CL_ParseServerInfo
 static void CL_ParseServerInfo (void)
 {
 	const char	*str;
-	int		i, j, argc, intval;
-	float	floatval;
+	int		i, j, argc;
 	int		nummodels, numsounds, numfx;
 	char	model_precache[MAX_MODELS][MAX_QPATH];
 	char	sound_precache[MAX_SOUNDS][MAX_QPATH];
@@ -417,26 +416,29 @@ static void CL_ParseServerInfo (void)
 	player_models[3] = (qmodel_t *)Mod_FindName ("models/assassin.mdl");
 	player_models[4] = (gameflags & GAME_PORTALS) ? (qmodel_t *)Mod_FindName ("models/succubus.mdl") : NULL;
 
-// load model fx from server
-	for (numfx = 1; ; numfx++)
+	if (cl_protocol == PROTOCOL_UH2_114)
 	{
-		str = MSG_ReadString();
-		if (!str[0])
-			break;
-		if (numfx == MAX_MODELS)
+		// load model fx from server
+		for (numfx = 1; ; numfx++)
 		{
-			Con_Printf("Server sent too many model effects\n");
-			return;
-		}
-		for (j = 2; j < nummodels; j++)
-		{
-			if (!strcmp(sv.model_precache[j], str))
+			str = MSG_ReadString();
+			if (!str[0])
+				break;
+			if (numfx == MAX_MODELS)
 			{
-				cl.model_precache[j]->ex_flags = MSG_ReadShort();
-				cl.model_precache[j]->glow_color[0] = MSG_ReadFloat();
-				cl.model_precache[j]->glow_color[1] = MSG_ReadFloat();
-				cl.model_precache[j]->glow_color[2] = MSG_ReadFloat();
-				cl.model_precache[j]->glow_color[3] = MSG_ReadFloat();
+				Con_Printf("Server sent too many model effects\n");
+				return;
+			}
+			for (j = 2; j < nummodels; j++)
+			{
+				if (!strcmp(sv.model_precache[j], str))
+				{
+					cl.model_precache[j]->ex_flags = MSG_ReadShort();
+					cl.model_precache[j]->glow_color[0] = MSG_ReadFloat();
+					cl.model_precache[j]->glow_color[1] = MSG_ReadFloat();
+					cl.model_precache[j]->glow_color[2] = MSG_ReadFloat();
+					cl.model_precache[j]->glow_color[3] = MSG_ReadFloat();
+				}
 			}
 		}
 	}
@@ -1175,7 +1177,6 @@ void CL_ParseServerMessage (void)
 {
 	int		cmd;
 	int		i, j, k;
-	float	l, m, n, o;
 	int		EntityCount = 0;
 	int		EntitySize = 0;
 	int		before;
@@ -1822,34 +1823,6 @@ void CL_ParseServerMessage (void)
 		case svc_skybox:
 			MSG_ReadString();
 			Con_DPrintf ("Ignored server msg %d (%s)\n", cmd, svc_strings[cmd]);
-			break;
-
-		case svc_set_extra_flags:
-			i = MSG_ReadShort();
-			j = MSG_ReadShort();
-			if (cl_entities[i].model != NULL)
-			{
-				cl_entities[i].model->ex_flags = j;
-				cl_entities[i].model->glow_color[0] = 0.2f;
-				cl_entities[i].model->glow_color[1] = 0.2f;
-				cl_entities[i].model->glow_color[2] = 0.2f;
-				cl_entities[i].model->glow_color[3] = 0.5f;
-			}
-			break;
-
-		case svc_set_glow_color:
-			i = MSG_ReadShort();
-			l = MSG_ReadCoord();
-			m = MSG_ReadCoord();
-			n = MSG_ReadCoord();
-			o = MSG_ReadCoord();
-			if (cl_entities[i].model != NULL)
-			{
-				cl_entities[i].model->glow_color[0] = l;
-				cl_entities[i].model->glow_color[1] = m;
-				cl_entities[i].model->glow_color[2] = n;
-				cl_entities[i].model->glow_color[3] = o;
-			}
 			break;
 		}
 	}

--- a/engine/hexen2/cl_parse.c
+++ b/engine/hexen2/cl_parse.c
@@ -250,8 +250,9 @@ CL_ParseServerInfo
 static void CL_ParseServerInfo (void)
 {
 	const char	*str;
-	int		i, argc;
-	int		nummodels, numsounds;
+	int		i, j, argc, intval;
+	float	floatval;
+	int		nummodels, numsounds, numfx;
 	char	model_precache[MAX_MODELS][MAX_QPATH];
 	char	sound_precache[MAX_SOUNDS][MAX_QPATH];
 // rjr	edict_t		*ent;
@@ -415,6 +416,30 @@ static void CL_ParseServerInfo (void)
 	player_models[2] = !(gameflags & GAME_OLD_DEMO) ? (qmodel_t *)Mod_FindName ("models/necro.mdl") : NULL;
 	player_models[3] = (qmodel_t *)Mod_FindName ("models/assassin.mdl");
 	player_models[4] = (gameflags & GAME_PORTALS) ? (qmodel_t *)Mod_FindName ("models/succubus.mdl") : NULL;
+
+// load model fx from server
+	for (numfx = 1; ; numfx++)
+	{
+		str = MSG_ReadString();
+		if (!str[0])
+			break;
+		if (numfx == MAX_MODELS)
+		{
+			Con_Printf("Server sent too many model effects\n");
+			return;
+		}
+		for (j = 2; j < nummodels; j++)
+		{
+			if (!strcmp(sv.model_precache[j], str))
+			{
+				cl.model_precache[j]->ex_flags = MSG_ReadShort();
+				cl.model_precache[j]->glow_color[0] = MSG_ReadFloat();
+				cl.model_precache[j]->glow_color[1] = MSG_ReadFloat();
+				cl.model_precache[j]->glow_color[2] = MSG_ReadFloat();
+				cl.model_precache[j]->glow_color[3] = MSG_ReadFloat();
+			}
+		}
+	}
 
 	S_BeginPrecaching ();
 	for (i = 1; i < numsounds; i++)

--- a/engine/hexen2/cl_parse.c
+++ b/engine/hexen2/cl_parse.c
@@ -1150,6 +1150,7 @@ void CL_ParseServerMessage (void)
 {
 	int		cmd;
 	int		i, j, k;
+	float	l, m, n, o;
 	int		EntityCount = 0;
 	int		EntitySize = 0;
 	int		before;
@@ -1796,6 +1797,34 @@ void CL_ParseServerMessage (void)
 		case svc_skybox:
 			MSG_ReadString();
 			Con_DPrintf ("Ignored server msg %d (%s)\n", cmd, svc_strings[cmd]);
+			break;
+
+		case svc_set_extra_flags:
+			i = MSG_ReadShort();
+			j = MSG_ReadShort();
+			if (cl_entities[i].model != NULL)
+			{
+				cl_entities[i].model->ex_flags = j;
+				cl_entities[i].model->glow_color[0] = 0.2f;
+				cl_entities[i].model->glow_color[1] = 0.2f;
+				cl_entities[i].model->glow_color[2] = 0.2f;
+				cl_entities[i].model->glow_color[3] = 0.5f;
+			}
+			break;
+
+		case svc_set_glow_color:
+			i = MSG_ReadShort();
+			l = MSG_ReadCoord();
+			m = MSG_ReadCoord();
+			n = MSG_ReadCoord();
+			o = MSG_ReadCoord();
+			if (cl_entities[i].model != NULL)
+			{
+				cl_entities[i].model->glow_color[0] = l;
+				cl_entities[i].model->glow_color[1] = m;
+				cl_entities[i].model->glow_color[2] = n;
+				cl_entities[i].model->glow_color[3] = o;
+			}
 			break;
 		}
 	}

--- a/engine/hexen2/pr_cmds.c
+++ b/engine/hexen2/pr_cmds.c
@@ -3227,9 +3227,9 @@ static void PF_set_extra_flags(void)
 	{
 		if (!strcmp(sv.model_precache[i], s))
 		{
-#if !defined(SERVERONLY)
+			#if !defined(SERVERONLY)
 			sv.models[i]->ex_flags = flags;
-#endif	/* SERVERONLY */
+			#endif	/* SERVERONLY */
 			return;
 		}
 	}
@@ -3258,12 +3258,12 @@ static void PF_set_fx_color(void)
 	{
 		if (!strcmp(sv.model_precache[i], s))
 		{
-#if !defined(SERVERONLY)
+			#if !defined(SERVERONLY)
 			sv.models[i]->glow_color[0] = j;
 			sv.models[i]->glow_color[1] = k;
 			sv.models[i]->glow_color[2] = l;
 			sv.models[i]->glow_color[3] = m;
-#endif	/* SERVERONLY */
+			#endif	/* SERVERONLY */
 			return;
 		}
 	}

--- a/engine/hexen2/pr_cmds.c
+++ b/engine/hexen2/pr_cmds.c
@@ -3209,6 +3209,68 @@ static void PF_doWhiteFlash(void)
 }
 
 
+static void PF_set_extra_flags(void)
+{
+	const char	*s;
+	int		flags;
+	int		i;
+
+	if (sv.state != ss_loading && !ignore_precache)
+		PR_RunError("%s: Model Extra Flags can only be changed in spawn functions", __thisfunc__);
+
+	s = G_STRING(OFS_PARM0);
+	flags = (int)G_FLOAT(OFS_PARM1);
+	G_INT(OFS_RETURN) = G_INT(OFS_PARM1);
+	PR_CheckEmptyString(s);
+
+	for (i = 0; i < MAX_MODELS; i++)
+	{
+		if (!strcmp(sv.model_precache[i], s))
+		{
+#if !defined(SERVERONLY)
+			sv.models[i]->ex_flags = flags;
+#endif	/* SERVERONLY */
+			return;
+		}
+	}
+	//PR_RunError("%s: overflow", __thisfunc__);
+}
+
+
+static void PF_set_fx_color(void)
+{
+	const char	*s;
+	int		i;
+	float j, k, l, m;
+
+	if (sv.state != ss_loading && !ignore_precache)
+		PR_RunError("%s: Model Effect Color can only be set in spawn functions", __thisfunc__);
+
+	s = G_STRING(OFS_PARM0);
+	j = G_FLOAT(OFS_PARM1);
+	k = G_FLOAT(OFS_PARM2);
+	l = G_FLOAT(OFS_PARM3);
+	m = G_FLOAT(OFS_PARM4);
+	G_INT(OFS_RETURN) = G_INT(OFS_PARM4);
+	PR_CheckEmptyString(s);
+
+	for (i = 0; i < MAX_MODELS; i++)
+	{
+		if (!strcmp(sv.model_precache[i], s))
+		{
+#if !defined(SERVERONLY)
+			sv.models[i]->glow_color[0] = j;
+			sv.models[i]->glow_color[1] = k;
+			sv.models[i]->glow_color[2] = l;
+			sv.models[i]->glow_color[3] = m;
+#endif	/* SERVERONLY */
+			return;
+		}
+	}
+	//PR_RunError("%s: overflow", __thisfunc__);
+}
+
+
 static builtin_t pr_builtin[] =
 {
 	PF_Fixme,
@@ -3337,7 +3399,6 @@ static builtin_t pr_builtin[] =
 	PF_doWhiteFlash,	// 104
 	PF_UpdateSoundPos,	// 105
 	PF_StopSound,		// 106
-
 #ifdef QUAKE2
 	PF_sin,
 	PF_cos,
@@ -3347,8 +3408,8 @@ static builtin_t pr_builtin[] =
 	PF_etos,
 	PF_WaterMove,
 #else
-	PF_Fixme,
-	PF_Fixme,
+	PF_set_extra_flags,	// void(string model, int flags) set_extra_flags	= #107
+	PF_set_fx_color,	// void(string model, float r, float g, float b, float a) set_fx_color	= #108
 	PF_Fixme,
 	PF_Fixme,
 	PF_Fixme,

--- a/engine/hexen2/protocol.h
+++ b/engine/hexen2/protocol.h
@@ -107,8 +107,6 @@
 #define	svc_sound_update_pos	53	// [short] ent+channel [coord3] pos
 #define	svc_mod_name		54	// [string] name (UQE v1.13 by Korax, music file name)
 #define	svc_skybox		55	// [string] name (UQE v1.13 by Korax, skybox name)
-#define svc_set_extra_flags	56 //[short] entity number, [short] flags
-#define svc_set_glow_color	57 //[short] entity number, [float] r, [float] g, [float] b, [float] a
 
 //==============================================
 

--- a/engine/hexen2/protocol.h
+++ b/engine/hexen2/protocol.h
@@ -107,6 +107,8 @@
 #define	svc_sound_update_pos	53	// [short] ent+channel [coord3] pos
 #define	svc_mod_name		54	// [string] name (UQE v1.13 by Korax, music file name)
 #define	svc_skybox		55	// [string] name (UQE v1.13 by Korax, skybox name)
+#define svc_set_extra_flags	56 //[short] entity number, [short] flags
+#define svc_set_glow_color	57 //[short] entity number, [float] r, [float] g, [float] b, [float] a
 
 //==============================================
 

--- a/engine/hexen2/sv_main.c
+++ b/engine/hexen2/sv_main.c
@@ -477,9 +477,25 @@ static void SV_SendServerinfo (client_t *client)
 		MSG_WriteString (&client->message, *s);
 	MSG_WriteByte (&client->message, 0);
 
-	for (i = 1, s = sv.sound_precache + 1; i < MAX_SOUNDS && *s; s++)
+	for (i = 1, s = sv.sound_precache + 1; i < MAX_SOUNDS && *s; s++) //i is not incrementing, this can overflow
 		MSG_WriteString (&client->message, *s);
 	MSG_WriteByte (&client->message, 0);
+
+// send model effects
+	for (i = 1, s = sv.model_precache + 1; i < MAX_MODELS && *s; s++)
+	{
+		if (sv.models[i]->ex_flags != 0)
+		{
+			MSG_WriteString(&client->message, *s);
+			MSG_WriteShort(&client->message, sv.models[i]->ex_flags);
+			MSG_WriteFloat(&client->message, sv.models[i]->glow_color[0]);
+			MSG_WriteFloat(&client->message, sv.models[i]->glow_color[1]);
+			MSG_WriteFloat(&client->message, sv.models[i]->glow_color[2]);
+			MSG_WriteFloat(&client->message, sv.models[i]->glow_color[3]);
+		}
+		i++;
+	}
+	MSG_WriteByte(&client->message, 0);
 
 // send music
 	MSG_WriteByte (&client->message, svc_cdtrack);

--- a/engine/hexen2/sv_main.c
+++ b/engine/hexen2/sv_main.c
@@ -481,21 +481,24 @@ static void SV_SendServerinfo (client_t *client)
 		MSG_WriteString (&client->message, *s);
 	MSG_WriteByte (&client->message, 0);
 
-// send model effects
-	for (i = 1, s = sv.model_precache + 1; i < MAX_MODELS && *s; s++)
+	if (sv_protocol == PROTOCOL_UH2_114)
 	{
-		if (sv.models[i]->ex_flags != 0)
+		// send model effects
+		for (i = 1, s = sv.model_precache + 1; i < MAX_MODELS && *s; s++)
 		{
-			MSG_WriteString(&client->message, *s);
-			MSG_WriteShort(&client->message, sv.models[i]->ex_flags);
-			MSG_WriteFloat(&client->message, sv.models[i]->glow_color[0]);
-			MSG_WriteFloat(&client->message, sv.models[i]->glow_color[1]);
-			MSG_WriteFloat(&client->message, sv.models[i]->glow_color[2]);
-			MSG_WriteFloat(&client->message, sv.models[i]->glow_color[3]);
+			if (sv.models[i]->ex_flags != 0)
+			{
+				MSG_WriteString(&client->message, *s);
+				MSG_WriteShort(&client->message, sv.models[i]->ex_flags);
+				MSG_WriteFloat(&client->message, sv.models[i]->glow_color[0]);
+				MSG_WriteFloat(&client->message, sv.models[i]->glow_color[1]);
+				MSG_WriteFloat(&client->message, sv.models[i]->glow_color[2]);
+				MSG_WriteFloat(&client->message, sv.models[i]->glow_color[3]);
+			}
+			i++;
 		}
-		i++;
+		MSG_WriteByte(&client->message, 0);
 	}
-	MSG_WriteByte(&client->message, 0);
 
 // send music
 	MSG_WriteByte (&client->message, svc_cdtrack);


### PR DESCRIPTION
Scripts can now add colored glow effects to models during precache.  This will set the glow effect for all instances of the model, and will transmit this info to clients on connecting.