### PR TITLE
Shanjaq/fix cl parse

### DIFF
--- a/engine/h2shared/gl_model.h
+++ b/engine/h2shared/gl_model.h
@@ -418,6 +418,7 @@ typedef enum {mod_brush, mod_sprite, mod_alias} modtype_t;
 #define XF_TORCH_GLOW_EGYPT	(1 << 30)	/* glowing torches, egypt			*/
 #define XF_GLOW			(1 << 1 )	/* other glows					*/
 #define XF_MISSILE_GLOW		(1 << 2 )	/* missile glows				*/
+#define XF_COLOR_LIGHT		(1 << 3 )	/* color dynamic light			*/
 
 typedef struct qmodel_s
 {

--- a/engine/h2shared/quakefs.c
+++ b/engine/h2shared/quakefs.c
@@ -60,6 +60,7 @@ static const char	*fs_basedir;
 static char	fs_gamedir[MAX_OSPATH];
 static char	fs_userdir[MAX_OSPATH];
 char	fs_gamedir_nopath[MAX_QPATH];
+char	fs_gamedir_list[MAX_QPATH];
 cvar_t	sv_gamedir = { "*gamedir", "", CVAR_NOTIFY | CVAR_SERVERINFO };
 static char gamedirs[MAX_QPATH];
 
@@ -489,7 +490,7 @@ void FS_Gamedir (const char *dir)
 		}
 	}
 
-	if (!q_strcasecmp(fs_gamedir_nopath, dir))
+	if (!q_strcasecmp(fs_gamedir_list, dir))
 		return;		/* still the same */
 
 /* free up any current game dir info: our top searchpath dir will be hw
@@ -562,6 +563,7 @@ void FS_Gamedir (const char *dir)
 		FS_AddGameDirectory(argv[i], false);
 	}
 
+	q_snprintf(fs_gamedir_list, sizeof(fs_gamedir_list), "%s", dir);
 //#if defined(SERVERONLY)
 /* change the *gamedir serverinfo properly */
 	q_snprintf(gamedirs, sizeof(gamedirs), "%s", dir);

--- a/engine/h2shared/quakefs.c
+++ b/engine/h2shared/quakefs.c
@@ -453,7 +453,7 @@ void FS_Gamedir (const char *dir)
 	int argc;
 	searchpath_t	*next;
 
-	if (!*dir || !strcmp(dir, ".") || strstr(dir, "..") || strstr(dir, "/") || strstr(dir, "\\") || strstr(dir, ":"))
+	if (!*dir || !strcmp(dir, ".") || strstr(dir, "..") || strstr(dir, "/") || strstr(dir, "\\") || strstr(dir, ":") || strstr(dir, "<") || strstr(dir, ">"))
 	{
 		if (!host_initialized)
 			Sys_Error ("gamedir should be a directory name list, not a path\n");
@@ -532,7 +532,7 @@ void FS_Gamedir (const char *dir)
 			Con_Printf("WARNING: Gamedir not set to hw :\n"
 				"It is reserved for HexenWorld.\n");
 #endif	/* H2W */
-			return;
+			break;
 	}
 
 		if (!q_strcasecmp(argv[i], "portals"))
@@ -544,7 +544,7 @@ void FS_Gamedir (const char *dir)
 #ifdef H2W
 			set_hw_dir();
 #endif
-			return;
+			break;
 		}
 
 		if (!q_strcasecmp(argv[i], "data1"))
@@ -556,7 +556,7 @@ void FS_Gamedir (const char *dir)
 #ifdef H2W
 			set_hw_dir();
 #endif
-			return;
+			break;
 		}
 
 		/* a new gamedir: let's set it here. */

--- a/engine/h2shared/quakefs.h
+++ b/engine/h2shared/quakefs.h
@@ -48,6 +48,7 @@
 #define	GAME_MODIFIED		(1 << 16)
 
 extern	char	fs_gamedir_nopath[MAX_QPATH];
+extern	char	fs_gamedir_list[MAX_QPATH];
 
 const char *FS_GetBasedir (void);
 const char *FS_GetUserbase (void);

--- a/engine/hexen2/cl_parse.c
+++ b/engine/hexen2/cl_parse.c
@@ -296,7 +296,7 @@ static void CL_ParseServerInfo (void)
 // parse gamedir
 	str = MSG_ReadString();
 
-	if (q_strcasecmp(fs_gamedir_nopath, str))
+	if (q_strcasecmp(fs_gamedir_list, str))
 	{
 		Con_Printf("Server set the gamedir to %s\n", str);
 		// save current config


### PR DESCRIPTION
only exec configs once on joining a modded server, saving any config changes to the last gamedir to load