### PR TITLE
\1 to \4 escape sequences to switch the charset used in messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -325,4 +325,3 @@ ASALocalRun/
 *.vcproj
 *.res
 *.exe
-/CppProperties.json

--- a/.gitignore
+++ b/.gitignore
@@ -325,3 +325,4 @@ ASALocalRun/
 *.vcproj
 *.res
 *.exe
+/CppProperties.json

--- a/engine/h2shared/gl_screen.c
+++ b/engine/h2shared/gl_screen.c
@@ -141,7 +141,7 @@ static int	scr_erase_lines;
 
 #define	MAXLINES	27
 static int	lines;
-static int	StartC[MAXLINES], EndC[MAXLINES];
+static int	StartC[MAXLINES], EndC[MAXLINES], CorrectionC[MAXLINES];
 
 #if !defined(H2W)
 /* mission pack objectives: */
@@ -190,10 +190,13 @@ static void FindTextBreaks (const char *message, int Width)
 
 	lines = pos = start = 0;
 	lastspace = -1;
+	CorrectionC[lines] = 0;
 
 	while (1)
 	{
-		if (pos-start >= Width || message[pos] == '@' || message[pos] == 0)
+		if (message[pos] == '\\' && (message[pos + 1] == '1' || message[pos + 1] == '2' || message[pos + 1] == '3' || message[pos + 1] == '4')) CorrectionC[lines] -= 2; 
+		
+		if (pos - start + CorrectionC[lines] >= Width || message[pos] == '@' || message[pos] == 0)
 		{
 			oldlast = lastspace;
 			if (message[pos] == '@' || lastspace == -1 || message[pos] == 0)
@@ -202,6 +205,7 @@ static void FindTextBreaks (const char *message, int Width)
 			StartC[lines] = start;
 			EndC[lines] = lastspace;
 			lines++;
+			CorrectionC[lines] = 0;
 			if (lines == MAXLINES)
 				return;
 			if (message[pos] == '@')
@@ -255,7 +259,7 @@ static void SCR_DrawCenterString (void)
 		cnt = EndC[i] - StartC[i];
 		strncpy (temp, &scr_centerstring[StartC[i]], cnt);
 		temp[cnt] = 0;
-		bx = (40-strlen(temp)) * 8 / 2;
+		bx = (40-strlen(temp) - CorrectionC[i]) * 8 / 2;
 		M_Print (bx, by, temp);
 	}
 }
@@ -988,7 +992,7 @@ static void Plaque_Draw (const char *message, qboolean AlwaysDraw)
 		cnt = EndC[i] - StartC[i];
 		strncpy (temp, &message[StartC[i]], cnt);
 		temp[cnt] = 0;
-		bx = (40-strlen(temp)) * 8 / 2;
+		bx = (40-strlen(temp) - CorrectionC[i]) * 8 / 2;
 		M_Print (bx, by, temp);
 	}
 }
@@ -1022,7 +1026,7 @@ static void Info_Plaque_Draw (const char *message)
 		cnt = EndC[i] - StartC[i];
 		strncpy (temp, &message[StartC[i]], cnt);
 		temp[cnt] = 0;
-		bx = (40-strlen(temp)) * 8 / 2;
+		bx = (40-strlen(temp) - CorrectionC[i]) * 8 / 2;
 		M_Print (bx, by, temp);
 	}
 }
@@ -1050,7 +1054,7 @@ static void Bottom_Plaque_Draw (const char *message)
 		cnt = EndC[i] - StartC[i];
 		strncpy (temp, &message[StartC[i]], cnt);
 		temp[cnt] = 0;
-		bx = (40-strlen(temp)) * 8 / 2;
+		bx = (40-strlen(temp) - CorrectionC[i]) * 8 / 2;
 		M_Print (bx, by, temp);
 	}
 }
@@ -1157,7 +1161,7 @@ static void SB_IntermissionOverlay (void)
 			size = elapsed;
 		temp[size] = 0;
 
-		bx = (40-strlen(temp)) * 8 / 2;
+		bx = (40-strlen(temp) - CorrectionC[i]) * 8 / 2;
 		I_Print (bx, by, temp, cl.intermission_flags);
 
 		elapsed -= size;

--- a/engine/h2shared/screen.c
+++ b/engine/h2shared/screen.c
@@ -143,7 +143,7 @@ static int	scr_erase_lines;
 
 #define	MAXLINES	27
 static int	lines;
-static int	StartC[MAXLINES], EndC[MAXLINES];
+static int	StartC[MAXLINES], EndC[MAXLINES], CorrectionC[MAXLINES];
 
 #if !defined(H2W)
 /* mission pack objectives: */
@@ -195,7 +195,9 @@ static void FindTextBreaks (const char *message, int Width)
 
 	while (1)
 	{
-		if (pos-start >= Width || message[pos] == '@' || message[pos] == 0)
+		if (message[pos] == '\\' && (message[pos + 1] == '1' || message[pos + 1] == '2' || message[pos + 1] == '3' || message[pos + 1] == '4')) CorrectionC[lines] -= 2; 
+		
+		if (pos - start + CorrectionC[lines] >= Width || message[pos] == '@' || message[pos] == 0)
 		{
 			oldlast = lastspace;
 			if (message[pos] == '@' || lastspace == -1 || message[pos] == 0)
@@ -204,6 +206,7 @@ static void FindTextBreaks (const char *message, int Width)
 			StartC[lines] = start;
 			EndC[lines] = lastspace;
 			lines++;
+			CorrectionC[lines] = 0;
 			if (lines == MAXLINES)
 				return;
 			if (message[pos] == '@')
@@ -279,7 +282,7 @@ static void SCR_DrawCenterString (void)
 		cnt = EndC[i] - StartC[i];
 		strncpy (temp, &scr_centerstring[StartC[i]], cnt);
 		temp[cnt] = 0;
-		bx = (40-strlen(temp)) * 8 / 2;
+		bx = (40-strlen(temp) - CorrectionC[i]) * 8 / 2;
 		M_Print (bx, by, temp);
 	}
 }
@@ -1072,7 +1075,7 @@ static void Plaque_Draw (const char *message, qboolean AlwaysDraw)
 		cnt = EndC[i] - StartC[i];
 		strncpy (temp, &message[StartC[i]], cnt);
 		temp[cnt] = 0;
-		bx = (40-strlen(temp)) * 8 / 2;
+		bx = (40-strlen(temp) - CorrectionC[i]) * 8 / 2;
 		M_Print (bx, by, temp);
 	}
 }
@@ -1108,7 +1111,7 @@ static void Info_Plaque_Draw (const char *message)
 		cnt = EndC[i] - StartC[i];
 		strncpy (temp, &message[StartC[i]], cnt);
 		temp[cnt] = 0;
-		bx = (40-strlen(temp)) * 8 / 2;
+		bx = (40-strlen(temp) - CorrectionC[i]) * 8 / 2;
 		M_Print (bx, by, temp);
 	}
 }
@@ -1134,7 +1137,7 @@ static void Bottom_Plaque_Draw (const char *message)
 		cnt = EndC[i] - StartC[i];
 		strncpy (temp, &message[StartC[i]], cnt);
 		temp[cnt] = 0;
-		bx = (40-strlen(temp)) * 8 / 2;
+		bx = (40-strlen(temp) - CorrectionC[i]) * 8 / 2;
 		M_Print (bx, by, temp);
 	}
 }
@@ -1241,7 +1244,7 @@ static void SB_IntermissionOverlay (void)
 			size = elapsed;
 		temp[size] = 0;
 
-		bx = (40-strlen(temp)) * 8 / 2;
+		bx = (40-strlen(temp) - CorrectionC[i]) * 8 / 2;
 		I_Print (bx, by, temp, cl.intermission_flags);
 
 		elapsed -= size;

--- a/engine/hexen2/menu.c
+++ b/engine/hexen2/menu.c
@@ -213,11 +213,36 @@ void M_DrawCharacter (int cx, int line, int num)
 
 void M_Print (int cx, int cy, const char *str)
 {
+	int charset_offset = 256; 
+	
 	while (*str)
 	{
-		M_DrawCharacter (cx, cy, ((unsigned char)(*str))+256);
-		str++;
-		cx += 8;
+		if (str[0] == '\\' && str[1] == '1')
+		{
+			charset_offset = 0;
+			str += 2;
+		}
+		else if (str[0] == '\\' && str[1] == '2')
+		{
+			charset_offset = 128;
+			str += 2;
+		}
+		else if (str[0] == '\\' && str[1] == '3')
+		{
+			charset_offset = 256;
+			str += 2;
+		}
+		else if (str[0] == '\\' && str[1] == '4')
+		{
+			charset_offset = 384;
+			str += 2;
+		}
+		else
+		{
+			M_DrawCharacter(cx, cy, ((unsigned char)(*str)) + charset_offset);
+			str++;
+			cx += 8;
+		}
 	}
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/72394209/135893014-ba716885-eb55-4e7e-b1b1-6b96c91136ee.png)
Above is my modified conchars.lmp for Wheel Of Karma.
The plaque and centerprint messages usually use the 2nd charset (here in yellow) whereas the console messages use the beige charset.
Both have theoretically 256 chars but only the 128 first are actually available because the last ones correspond to non ASCII chars which are not correctly parsed when strings.txt is read. So there are 2 groups of 128 unusable slots (surrounded in red in the screenshot) which are out of reach whereas they could be used for extra chars.
That's a big waste, so my idea is to consider that conchars is not only 2 charsets of 256 slots (both half unusable) but 4 fully usable charsets of 128 slots each.
I added the support for the escape sequences \1 to \4 to switch from one charset to another in the middle of a message in strings.txt.
Dummy example of what is now possible:
![image](https://user-images.githubusercontent.com/72394209/135892946-39452dbd-83db-4bde-a9c2-e4929db1b7b1.png)
There's a switch from the default third (yellow) charset to the beige charset for the name of Razumen and the navigation interface below the atmospheric text.
The "navigation arrows" to the previous/next page of text are brand new characters belonging to the 2nd charset (surrounded in purple in the first screenshot).

The proposed evol makes the charset switch available for:
* Centered plaques' messages
* Bottom plaques' messages
* Regular centerprint messages
* Info plaques messages (objectives)
* Inter-episodes intermission texts