### PR TITLE
Fix for a game crash while trying to display full inventory with ring items in it.

### DIFF
--- a/engine/h2shared/gl_texmgr.c
+++ b/engine/h2shared/gl_texmgr.c
@@ -802,6 +802,10 @@ static unsigned *TexMgr_ResampleTexture(unsigned *in, int inwidth, int inheight,
 
 	outwidth = TexMgr_Pad(inwidth);
 	outheight = TexMgr_Pad(inheight);
+
+	if (outwidth == 1) outwidth = 2;
+	if (outheight == 1) outheight = 2;
+
 	out = (unsigned *)Hunk_Alloc(outwidth*outheight * 4);
 
 	xfrac = ((inwidth - 1) << 16) / (outwidth - 1);


### PR DESCRIPTION
The crash happens in line 812 (originally 808) of gl_texmgr.c as a result of division by 0. But the real culprit is function TexMgr_Pad (gl_texmgr.c) which should return padded to the power of 2 texture size, but for some reason returns 1, if one of the texture dimensions equals 1. (should return 2) The texture in question is 1 pixel height image representing 'progress bar' below each ring. (rhlthcvr.lmp and/or ringhlth.lmp)