### PR TITLE
New function PimpModel to decorate models with cool client-side effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -325,4 +325,3 @@ ASALocalRun/
 *.vcproj
 *.res
 *.exe
-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -325,3 +325,4 @@ ASALocalRun/
 *.vcproj
 *.res
 *.exe
+*.json

--- a/engine/h2shared/gl_model.h
+++ b/engine/h2shared/gl_model.h
@@ -428,7 +428,6 @@ typedef enum {mod_brush, mod_sprite, mod_alias} modtype_t;
 #define	EF_SCARAB		(1 << 21)	/* white transparent particles with little gravity	*/
 #define	EF_ACIDBALL		(1 << 22)	/* Green drippy acid shit				*/
 #define	EF_BLOODSHOT		(1 << 23)	/* Blood rain shot trail				*/
-
 #define	EF_MIP_MAP_FAR		(1 << 24)	/* Set per frame, this model will use the far mip map	*/
 
 // XF_ Extra model effects set by engine: qmodel_t->ex_flags
@@ -438,6 +437,23 @@ typedef enum {mod_brush, mod_sprite, mod_alias} modtype_t;
 #define XF_GLOW			(1 << 1 )	/* other glows					*/
 #define XF_MISSILE_GLOW		(1 << 2 )	/* missile glows				*/
 #define XF_COLOR_LIGHT		(1 << 3 )	/* color dynamic light			*/
+#define	EF_SPIN				(1 << 4)	/* Inky: Rotate without floating upside down */
+#define	EF_FLOAT			(1 << 5)	/* Inky: Float upside down without rotating */
+#define	EF_GLOW				(1 << 6)	/* Inky: Feature a custom glowing orb around the model, override the various XF_*GLOW presets */
+#define	EF_ILLUMINATE		(1 << 7)	/* Inky: Cast light dynamically around */
+
+// slots for qmodel_t->glow_settings
+#define	GLOW_SETTINGS_COUNT 10
+#define	COLOR_R 0
+#define	COLOR_G 1
+#define	COLOR_B 2
+#define	COLOR_A 3
+#define	ORB_OFFSET_X 4
+#define	ORB_OFFSET_Y 5
+#define	ORB_OFFSET_Z 6
+#define	ORB_RADIUS 7
+#define	LIGHT_STYLE 8
+#define	LIGHT_RADIUS 9
 
 typedef struct qmodel_s
 {
@@ -511,7 +527,7 @@ typedef struct qmodel_s
 //
 // additional model data
 //
-	float		glow_color[4];
+	float		glow_settings[GLOW_SETTINGS_COUNT];
 
 	cache_user_t	cache;		// only access through Mod_Extradata - MUST BE LAST MEMBER
 } qmodel_t;

--- a/engine/h2shared/progs.h
+++ b/engine/h2shared/progs.h
@@ -89,7 +89,7 @@ extern	qboolean	is_progs_v6;
 
 void PR_Init (void);
 
-void PR_ExecuteProgram (func_t fnum);
+void PR_ExecuteProgram (func_t fnum, char* funcname);
 void PR_LoadProgs (void);
 
 const float* PR_GetFloat(int num);

--- a/engine/hexen2/cl_main.c
+++ b/engine/hexen2/cl_main.c
@@ -541,10 +541,12 @@ static float CL_LerpPoint (void)
 CL_RelinkEntities
 ===============
 */
+#define ftoi(f) ((int)(f >= 0.0 ? (f + 0.5) : (f - 0.5)))
+
 static void CL_RelinkEntities (void)
 {
 	entity_t	*ent;
-	int		i, j;
+	int		i, j, k, l;
 	float		frac, f, d;
 	vec3_t		delta;
 	vec3_t		oldorg;
@@ -647,10 +649,10 @@ static void CL_RelinkEntities (void)
 #		ifdef GLQUAKE
 			if (gl_colored_dynamic_lights.integer)
 			{	// Make the dynamic light yellow
-				dl->color[0] = (ent->model->glow_color[0] != 0.0 ? ent->model->glow_color[0] : 1.0);
-				dl->color[1] = (ent->model->glow_color[1] != 0.0 ? ent->model->glow_color[1] : 1.0);
-				dl->color[2] = (ent->model->glow_color[2] != 0.0 ? ent->model->glow_color[2] : 0.5);
-				dl->color[3] = (ent->model->glow_color[3] != 0.0 ? ent->model->glow_color[3] : 0.7);
+				dl->color[0] = (ent->model->glow_settings[COLOR_R] != 0.0 ? ent->model->glow_settings[COLOR_R] : 1.0);
+				dl->color[1] = (ent->model->glow_settings[COLOR_G] != 0.0 ? ent->model->glow_settings[COLOR_G] : 1.0);
+				dl->color[2] = (ent->model->glow_settings[COLOR_B] != 0.0 ? ent->model->glow_settings[COLOR_B] : 0.5);
+				dl->color[3] = (ent->model->glow_settings[COLOR_A] != 0.0 ? ent->model->glow_settings[COLOR_A] : 0.7);
 			}
 #		endif
 		}
@@ -664,10 +666,10 @@ static void CL_RelinkEntities (void)
 #		ifdef GLQUAKE
 			if (gl_colored_dynamic_lights.integer)
 			{
-				dl->color[0] = (ent->model->glow_color[0] != 0.0 ? ent->model->glow_color[0] : 0.8);
-				dl->color[1] = (ent->model->glow_color[1] != 0.0 ? ent->model->glow_color[1] : 0.8);
-				dl->color[2] = (ent->model->glow_color[2] != 0.0 ? ent->model->glow_color[2] : 1.0);
-				dl->color[3] = (ent->model->glow_color[3] != 0.0 ? ent->model->glow_color[3] : 0.7);
+				dl->color[0] = (ent->model->glow_settings[COLOR_R] != 0.0 ? ent->model->glow_settings[COLOR_R] : 0.8);
+				dl->color[1] = (ent->model->glow_settings[COLOR_G] != 0.0 ? ent->model->glow_settings[COLOR_G] : 0.8);
+				dl->color[2] = (ent->model->glow_settings[COLOR_B] != 0.0 ? ent->model->glow_settings[COLOR_B] : 1.0);
+				dl->color[3] = (ent->model->glow_settings[COLOR_A] != 0.0 ? ent->model->glow_settings[COLOR_A] : 0.7);
 			}
 #		endif
 		}
@@ -680,10 +682,10 @@ static void CL_RelinkEntities (void)
 #		ifdef GLQUAKE
 			if (gl_colored_dynamic_lights.integer)
 			{
-				dl->color[0] = (ent->model->glow_color[0] != 0.0 ? ent->model->glow_color[0] : 0.8);
-				dl->color[1] = (ent->model->glow_color[1] != 0.0 ? ent->model->glow_color[1] : 0.6);
-				dl->color[2] = (ent->model->glow_color[2] != 0.0 ? ent->model->glow_color[2] : 0.2);
-				dl->color[3] = (ent->model->glow_color[3] != 0.0 ? ent->model->glow_color[3] : 0.7);
+				dl->color[0] = (ent->model->glow_settings[COLOR_R] != 0.0 ? ent->model->glow_settings[COLOR_R] : 0.8);
+				dl->color[1] = (ent->model->glow_settings[COLOR_G] != 0.0 ? ent->model->glow_settings[COLOR_G] : 0.6);
+				dl->color[2] = (ent->model->glow_settings[COLOR_B] != 0.0 ? ent->model->glow_settings[COLOR_B] : 0.2);
+				dl->color[3] = (ent->model->glow_settings[COLOR_A] != 0.0 ? ent->model->glow_settings[COLOR_A] : 0.7);
 			}
 #		endif
 		}
@@ -705,12 +707,48 @@ static void CL_RelinkEntities (void)
 #		ifdef GLQUAKE
 			if (gl_colored_dynamic_lights.integer)
 			{
-				dl->color[0] = (ent->model->glow_color[0] != 0.0 ? ent->model->glow_color[0] : 0.8);
-				dl->color[1] = (ent->model->glow_color[1] != 0.0 ? ent->model->glow_color[1] : 0.4);
-				dl->color[2] = (ent->model->glow_color[2] != 0.0 ? ent->model->glow_color[2] : 0.2);
-				dl->color[3] = (ent->model->glow_color[3] != 0.0 ? ent->model->glow_color[3] : 0.7);
+				dl->color[0] = (ent->model->glow_settings[COLOR_R] != 0.0 ? ent->model->glow_settings[COLOR_R] : 0.8);
+				dl->color[1] = (ent->model->glow_settings[COLOR_G] != 0.0 ? ent->model->glow_settings[COLOR_G] : 0.4);
+				dl->color[2] = (ent->model->glow_settings[COLOR_B] != 0.0 ? ent->model->glow_settings[COLOR_B] : 0.2);
+				dl->color[3] = (ent->model->glow_settings[COLOR_A] != 0.0 ? ent->model->glow_settings[COLOR_A] : 0.7);
 			}
 #		endif
+		}
+		if (ent->model->ex_flags & EF_ILLUMINATE)
+		{
+			dl = CL_AllocDlight(i);
+			VectorCopy(ent->origin, dl->origin);
+			dl->origin[0] += ent->model->glow_settings[ORB_OFFSET_X];
+			dl->origin[1] += ent->model->glow_settings[ORB_OFFSET_Y];
+			dl->origin[2] += ent->model->glow_settings[ORB_OFFSET_Z];
+			dl->radius = (ent->model->glow_settings[LIGHT_RADIUS] >= 1.0 ? ent->model->glow_settings[LIGHT_RADIUS] : 200);
+			dl->die = cl.time + 0.001;
+#		ifdef GLQUAKE
+			if (gl_colored_dynamic_lights.integer)
+			{
+				dl->color[0] = (ent->model->glow_settings[COLOR_R] != 0.0 ? ent->model->glow_settings[COLOR_R] : 1.0);
+				dl->color[1] = (ent->model->glow_settings[COLOR_G] != 0.0 ? ent->model->glow_settings[COLOR_G] : 1.0);
+				dl->color[2] = (ent->model->glow_settings[COLOR_B] != 0.0 ? ent->model->glow_settings[COLOR_B] : 1.0);
+				dl->color[3] = (ent->model->glow_settings[COLOR_A] != 0.0 ? ent->model->glow_settings[COLOR_A] : 1.0);
+			}
+#		endif
+			// Now apply the light style
+			k = (int)(cl.time * 10);
+			l = 0;
+			if (!cl_lightstyle[ftoi(ent->model->glow_settings[LIGHT_STYLE])].length)
+			{
+				l = 256;
+			}
+			else
+			{
+				l = k % cl_lightstyle[ftoi(ent->model->glow_settings[LIGHT_STYLE])].length;
+				l = cl_lightstyle[ftoi(ent->model->glow_settings[LIGHT_STYLE])].map[l] - 'a';
+				l = l * 22;
+			}
+			float intensity = ((float)l / 255.0f);
+			dl->color[0] *= intensity;
+			dl->color[1] *= intensity;
+			dl->color[2] *= intensity;
 		}
 
 		if (ent->model->flags & EF_GIB)

--- a/engine/hexen2/cl_parse.c
+++ b/engine/hexen2/cl_parse.c
@@ -416,10 +416,10 @@ static void CL_ParseServerInfo (void)
 				{
 					#ifdef GLQUAKE
 					cl.model_precache[j]->ex_flags = MSG_ReadShort();
-					cl.model_precache[j]->glow_color[0] = MSG_ReadFloat();
-					cl.model_precache[j]->glow_color[1] = MSG_ReadFloat();
-					cl.model_precache[j]->glow_color[2] = MSG_ReadFloat();
-					cl.model_precache[j]->glow_color[3] = MSG_ReadFloat();
+					cl.model_precache[j]->glow_settings[COLOR_R] = MSG_ReadFloat();
+					cl.model_precache[j]->glow_settings[COLOR_G] = MSG_ReadFloat();
+					cl.model_precache[j]->glow_settings[COLOR_B] = MSG_ReadFloat();
+					cl.model_precache[j]->glow_settings[COLOR_A] = MSG_ReadFloat();
 					#endif
 				}
 			}

--- a/engine/hexen2/cl_tent.c
+++ b/engine/hexen2/cl_tent.c
@@ -292,10 +292,10 @@ void CL_ParseTEnt(void)
 #	ifdef GLQUAKE
 		if ((gl_colored_dynamic_lights.integer) && (ent->model))
 		{
-			dl->color[0] = ent->model->glow_color[0];
-			dl->color[1] = ent->model->glow_color[1];
-			dl->color[2] = ent->model->glow_color[2];
-			dl->color[3] = ent->model->glow_color[3];
+			dl->color[0] = ent->model->glow_settings[COLOR_R];
+			dl->color[1] = ent->model->glow_settings[COLOR_G];
+			dl->color[2] = ent->model->glow_settings[COLOR_B];
+			dl->color[3] = ent->model->glow_settings[COLOR_A];
 		}
 #	endif
 		break;

--- a/engine/hexen2/gl_model.c
+++ b/engine/hexen2/gl_model.c
@@ -2627,235 +2627,263 @@ static void Mod_SetAliasModelExtraFlags (qmodel_t *mod)
 	// Torch glows
 	if (!q_strncasecmp (mod->name, "models/rflmtrch",15) ||
 	    !q_strncasecmp (mod->name, "models/cflmtrch",15) ||
-	    !q_strncasecmp (mod->name, "models/castrch",15)  ||
+	    !q_strncasecmp (mod->name, "models/castrch",14)  ||
 	    !q_strncasecmp (mod->name, "models/rometrch",15) ||
 	    !q_strncasecmp (mod->name, "models/egtorch",14)  ||
 	    !q_strncasecmp (mod->name, "models/flame",12))
 	{
 		mod->ex_flags |= XF_TORCH_GLOW;
 		// set yellow color
-		mod->glow_color[0] = 0.8f;
-		mod->glow_color[1] = 0.4f;
-		mod->glow_color[2] = 0.1f;
-		mod->glow_color[3] = 1.0f;
+		mod->glow_settings[COLOR_R] = 0.8f;
+		mod->glow_settings[COLOR_G] = 0.4f;
+		mod->glow_settings[COLOR_B] = 0.1f;
+		mod->glow_settings[COLOR_A] = 1.0f;
+		mod->glow_settings[LIGHT_STYLE] = 1; //TORCH_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/eflmtrch",15))
 	{
 		mod->ex_flags |= (XF_TORCH_GLOW | XF_TORCH_GLOW_EGYPT);
-		mod->glow_color[0] = 0.8f;
-		mod->glow_color[1] = 0.4f;
-		mod->glow_color[2] = 0.1f;
-		mod->glow_color[3] = 1.0f;
+		mod->glow_settings[COLOR_R] = 0.8f;
+		mod->glow_settings[COLOR_G] = 0.4f;
+		mod->glow_settings[COLOR_B] = 0.1f;
+		mod->glow_settings[COLOR_A] = 1.0f;
+		mod->glow_settings[LIGHT_STYLE] = 1; //TORCH_STYLE
 	}
 	// Mana glows
 	else if (!q_strncasecmp (mod->name, "models/i_bmana",14))
 	{
 		mod->ex_flags |= XF_GLOW;
-		mod->glow_color[0] = 0.25f;
-		mod->glow_color[1] = 0.25f;
-		mod->glow_color[2] = 1.0f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 0.25f;
+		mod->glow_settings[COLOR_G] = 0.25f;
+		mod->glow_settings[COLOR_B] = 1.0f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 11; //PULSE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/i_gmana",14))
 	{
 		mod->ex_flags |= XF_GLOW;
-		mod->glow_color[0] = 0.25f;
-		mod->glow_color[1] = 1.0f;
-		mod->glow_color[2] = 0.25f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 0.25f;
+		mod->glow_settings[COLOR_G] = 1.0f;
+		mod->glow_settings[COLOR_B] = 0.25f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 11; //PULSE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/i_btmana",15))
 	{
 		mod->ex_flags |= XF_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.25f;
-		mod->glow_color[2] = 0.25f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.25f;
+		mod->glow_settings[COLOR_B] = 0.25f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 11; //PULSE_STYLE
 	}
 	// Missile glows
 	else if (!q_strncasecmp (mod->name, "models/drgnball",15))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.75f;
-		mod->glow_color[2] = 0.25f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.75f;
+		mod->glow_settings[COLOR_B] = 0.25f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/eidoball",15))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.55f;
-		mod->glow_color[2] = 0.25f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.55f;
+		mod->glow_settings[COLOR_B] = 0.25f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/lavaball",15))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.75f;
-		mod->glow_color[2] = 0.25f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.75f;
+		mod->glow_settings[COLOR_B] = 0.25f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/glowball",15))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.75f;
-		mod->glow_color[2] = 0.25f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.75f;
+		mod->glow_settings[COLOR_B] = 0.25f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/fireball",15))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.25f;
-		mod->glow_color[2] = 0.25f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.25f;
+		mod->glow_settings[COLOR_B] = 0.25f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/famshot",14))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 0.2f;
-		mod->glow_color[1] = 0.8f;
-		mod->glow_color[2] = 0.2f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 0.2f;
+		mod->glow_settings[COLOR_G] = 0.8f;
+		mod->glow_settings[COLOR_B] = 0.2f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/pestshot",15))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 0.2f;
-		mod->glow_color[1] = 0.2f;
-		mod->glow_color[2] = 0.2f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 0.2f;
+		mod->glow_settings[COLOR_G] = 0.2f;
+		mod->glow_settings[COLOR_B] = 0.2f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/mumshot",14))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.75f;
-		mod->glow_color[2] = 0.25f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.75f;
+		mod->glow_settings[COLOR_B] = 0.25f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/scrbstp1",15))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.75f;
-		mod->glow_color[2] = 0.05f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.75f;
+		mod->glow_settings[COLOR_B] = 0.05f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/scrbpbody",16))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.75f;
-		mod->glow_color[2] = 0.05f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.75f;
+		mod->glow_settings[COLOR_B] = 0.05f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/iceshot2",15))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 0.25f;
-		mod->glow_color[1] = 0.25f;
-		mod->glow_color[2] = 1.0f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 0.25f;
+		mod->glow_settings[COLOR_G] = 0.25f;
+		mod->glow_settings[COLOR_B] = 1.0f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/iceshot",14))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 0.25f;
-		mod->glow_color[1] = 0.25f;
-		mod->glow_color[2] = 1.0f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 0.25f;
+		mod->glow_settings[COLOR_G] = 0.25f;
+		mod->glow_settings[COLOR_B] = 1.0f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/flaming",14))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.75f;
-		mod->glow_color[2] = 0.55f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.75f;
+		mod->glow_settings[COLOR_B] = 0.55f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/sucwp1p",14))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 8.0f;
-		mod->glow_color[1] = 0.2f;
-		mod->glow_color[2] = 0.2f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 8.0f;
+		mod->glow_settings[COLOR_G] = 0.2f;
+		mod->glow_settings[COLOR_B] = 0.2f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/sucwp2p",14))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 0.2f;
-		mod->glow_color[1] = 0.8f;
-		mod->glow_color[2] = 0.2f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 0.2f;
+		mod->glow_settings[COLOR_G] = 0.8f;
+		mod->glow_settings[COLOR_B] = 0.2f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/goop",11))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.8f;
-		mod->glow_color[2] = 0.2f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.8f;
+		mod->glow_settings[COLOR_B] = 0.2f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/purfir1",14))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.75f;
-		mod->glow_color[2] = 0.25f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.75f;
+		mod->glow_settings[COLOR_B] = 0.25f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/golemmis",15))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.25f;
-		mod->glow_color[2] = 0.25f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.25f;
+		mod->glow_settings[COLOR_B] = 0.25f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/shard",12) && strlen(mod->name) == 12)
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.25f;
-		mod->glow_color[2] = 0.25f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.25f;
+		mod->glow_settings[COLOR_B] = 0.25f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/shardice",15))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 0.25f;
-		mod->glow_color[1] = 0.25f;
-		mod->glow_color[2] = 1.0f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 0.25f;
+		mod->glow_settings[COLOR_G] = 0.25f;
+		mod->glow_settings[COLOR_B] = 1.0f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/snakearr",15))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 0.25f;
-		mod->glow_color[2] = 0.25f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 0.25f;
+		mod->glow_settings[COLOR_B] = 0.25f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/spit",11))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 0.25f;
-		mod->glow_color[1] = 1.0f;
-		mod->glow_color[2] = 0.25f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 0.25f;
+		mod->glow_settings[COLOR_G] = 1.0f;
+		mod->glow_settings[COLOR_B] = 0.25f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 	else if (!q_strncasecmp (mod->name, "models/spike",12))
 	{
 		mod->ex_flags |= XF_MISSILE_GLOW;
-		mod->glow_color[0] = 1.0f;
-		mod->glow_color[1] = 1.0f;
-		mod->glow_color[2] = 1.0f;
-		mod->glow_color[3] = 0.5f;
+		mod->glow_settings[COLOR_R] = 1.0f;
+		mod->glow_settings[COLOR_G] = 1.0f;
+		mod->glow_settings[COLOR_B] = 1.0f;
+		mod->glow_settings[COLOR_A] = 0.5f;
+		mod->glow_settings[LIGHT_STYLE] = 6; //MISSILE_STYLE
 	}
 }
 

--- a/engine/hexen2/host.c
+++ b/engine/hexen2/host.c
@@ -543,7 +543,7 @@ void SV_DropClient (qboolean crash)
 		// this will set the body to a dead frame, among other things
 			saveSelf = *sv_globals.self;
 			*sv_globals.self = EDICT_TO_PROG(host_client->edict);
-			PR_ExecuteProgram (*sv_globals.ClientDisconnect);
+			PR_ExecuteProgram (*sv_globals.ClientDisconnect, "ClientDisconnect");
 			*sv_globals.self = saveSelf;
 		}
 

--- a/engine/hexen2/host_cmd.c
+++ b/engine/hexen2/host_cmd.c
@@ -977,7 +977,7 @@ static void RestoreClients (int ClientsMode)
 			*sv_globals.time = sv.time;
 			*sv_globals.self = EDICT_TO_PROG(ent);
 			G_FLOAT(OFS_PARM0) = time_diff;
-			PR_ExecuteProgram (*sv_globals.ClientReEnter);
+			PR_ExecuteProgram (*sv_globals.ClientReEnter, "ClientReEnter");
 		}
 	}
 
@@ -1319,7 +1319,7 @@ static void Host_Class_f (void)
 
 	// Change the weapon model used
 	*sv_globals.self = EDICT_TO_PROG(host_client->edict);
-	PR_ExecuteProgram (*sv_globals.ClassChangeWeapon);
+	PR_ExecuteProgram (*sv_globals.ClassChangeWeapon, "ClassChangeWeapon");
 
 // send notification to all clients
 	MSG_WriteByte (&sv.reliable_datagram, svc_updateclass);
@@ -1554,7 +1554,7 @@ static void Host_Kill_f (void)
 
 	*sv_globals.time = sv.time;
 	*sv_globals.self = EDICT_TO_PROG(sv_player);
-	PR_ExecuteProgram (*sv_globals.ClientKill);
+	PR_ExecuteProgram (*sv_globals.ClientKill, "ClientKill");
 }
 
 
@@ -1673,12 +1673,12 @@ static void Host_Spawn_f (void)
 			// call the spawn function
 			*sv_globals.time = sv.time;
 			*sv_globals.self = EDICT_TO_PROG(sv_player);
-			PR_ExecuteProgram (*sv_globals.ClientConnect);
+			PR_ExecuteProgram (*sv_globals.ClientConnect, "ClientConnect");
 
 			if ((Sys_DoubleTime() - NET_QSocketGetTime(host_client->netconnection)) <= sv.time)
 				Sys_Printf ("%s entered the game\n", host_client->name);
 
-			PR_ExecuteProgram (*sv_globals.PutClientInServer);
+			PR_ExecuteProgram (*sv_globals.PutClientInServer, "PutClientInServer");
 		}
 	}
 
@@ -1883,7 +1883,7 @@ static void Host_Create_f (void)
 
 	*sv_globals.self = EDICT_TO_PROG(ent);
 	ignore_precache = true;
-	PR_ExecuteProgram (func - pr_functions);
+	PR_ExecuteProgram (func - pr_functions, PR_GetString(func->s_name));
 	ignore_precache = false;
 }
 

--- a/engine/hexen2/pr_cmds.c
+++ b/engine/hexen2/pr_cmds.c
@@ -3324,10 +3324,10 @@ static void PF_set_fx_color(void)
 			if (!strcmp(sv.model_precache[i], s))
 			{
 				#if !defined(SERVERONLY) && defined(GLQUAKE)
-				sv.models[i]->glow_color[0] = j;
-				sv.models[i]->glow_color[1] = k;
-				sv.models[i]->glow_color[2] = l;
-				sv.models[i]->glow_color[3] = m;
+				sv.models[i]->glow_settings[COLOR_R] = j;
+				sv.models[i]->glow_settings[COLOR_G] = k;
+				sv.models[i]->glow_settings[COLOR_B] = l;
+				sv.models[i]->glow_settings[COLOR_A] = m;
 				#endif	/* SERVERONLY */
 				return;
 			}
@@ -3360,6 +3360,10 @@ static void PF_strhash(void)
 	//PR_RunError("%s: overflow", __thisfunc__);
 }
 
+static void PF_pimpmodel(void)
+{
+	G_FLOAT(OFS_RETURN) = PimpModel(G_EDICT(OFS_PARM0), G_VECTOR(OFS_PARM1));
+}
 
 static builtin_t pr_builtin[] =
 {
@@ -3502,7 +3506,7 @@ static builtin_t pr_builtin[] =
 	PF_set_fx_color,	// void(string model, float r, float g, float b, float a) set_fx_color	= #108
 	PF_strhash,		// float(string s1) strhash = #109
 	PF_centerprintf,
-	PF_Fixme,
+	PF_pimpmodel,   // float(entity e) applies all the model properties defined by e on the target model occurrences throughout the map = #111
 	PF_Fixme,
 	PF_Fixme,
 #endif

--- a/engine/hexen2/pr_edict.c
+++ b/engine/hexen2/pr_edict.c
@@ -700,17 +700,17 @@ ED_Print
 For debugging
 =============
 */
-void ED_Print (edict_t *ed)
+void ED_Print(edict_t* ed)
 {
-	ddef_t	*d;
-	int		*v;
+	ddef_t* d;
+	int* v;
 	int		i, j, l;
-	const char	*name;
+	const char* name;
 	int		type;
 
 	if (ed->free)
 	{
-		Con_Printf ("FREE\n");
+		Con_Printf("FREE\n");
 		return;
 	}
 
@@ -719,14 +719,14 @@ void ED_Print (edict_t *ed)
 	{
 		d = &pr_fielddefs[i];
 		name = PR_GetString(d->s_name);
-		l = strlen (name);
+		l = strlen(name);
 		j = l - 1;
-		if (j > 0 && name[j-1] == '_' && name[j] >= 'x' && name[j] <= 'z')
+		if (j > 0 && name[j - 1] == '_' && name[j] >= 'x' && name[j] <= 'z')
 			continue;	// skip _x, _y, _z vars
 
-		v = (int *)((char *)&ed->v + d->ofs*4);
+		v = (int*)((char*)&ed->v + d->ofs * 4);
 
-	// if the value is still all 0, skip the field
+		// if the value is still all 0, skip the field
 		type = d->type & ~DEF_SAVEGLOBAL;
 
 		for (j = 0; j < type_size[type]; j++)
@@ -737,12 +737,51 @@ void ED_Print (edict_t *ed)
 		if (j == type_size[type])
 			continue;
 
-		Con_Printf ("%s", name);
+		Con_Printf("%s", name);
 		while (l++ < 15)
-			Con_Printf (" ");
+			Con_Printf(" ");
 
-		Con_Printf ("%s\n", PR_ValueString(d->type, (eval_t *)v));
+		Con_Printf("%s\n", PR_ValueString(d->type, (eval_t*)v));
 	}
+}
+
+/*
+=============
+ED_GetProperty
+
+Get the value of an edict property by name
+=============
+*/
+const char* ED_GetProperty (edict_t *ed, char* propname)
+{
+	static char	ret[1];
+	ddef_t	*d;
+	int		*v;
+	int		i;
+	const char	*name;
+
+	ret[0] = '\0';
+
+	if (ed->free)
+		return ret;
+
+	for (i = 1; i < progs->numfielddefs; i++)
+	{
+		d = &pr_fielddefs[i];
+		name = PR_GetString(d->s_name);
+
+		if (!q_strncasecmp(name, propname, strlen(propname)))
+		{
+			v = (int*)((char*)&ed->v + d->ofs * 4);
+			return PR_ValueString(d->type, (eval_t*)v);
+		}
+		else
+		{
+			continue;
+		}
+	}
+
+	return ret;
 }
 
 /*
@@ -1373,7 +1412,7 @@ void ED_LoadFromFile (const char *data)
 		}
 
 		*sv_globals.self = EDICT_TO_PROG(ent);
-		PR_ExecuteProgram (func - pr_functions);
+		PR_ExecuteProgram (func - pr_functions, PR_GetString(ent->v.classname));
 	}
 
 	Con_DPrintf ("%i entities inhibited\n", inhibit);

--- a/engine/hexen2/pr_exec.c
+++ b/engine/hexen2/pr_exec.c
@@ -149,7 +149,7 @@ static const char *pr_opnames[] =
 #define OPC ((eval_t *)&pr_globals[st->c])
 #endif
 
-void PR_ExecuteProgram (func_t fnum)
+void PR_ExecuteProgram (func_t fnum, char* funcname)
 {
 	eval_t		*ptr, *a, *b, *c;
 	float		*vecptr;
@@ -162,6 +162,7 @@ void PR_ExecuteProgram (func_t fnum)
 	/* switch/case support:  */
 	int	case_type = -1;
 	float	switch_float = 0;
+	char error_msg[80];
 
 	if (!fnum || fnum >= progs->numfunctions)
 	{
@@ -169,7 +170,8 @@ void PR_ExecuteProgram (func_t fnum)
 		{
 			ED_Print(PROG_TO_EDICT(*sv_globals.self));
 		}
-		Host_Error("%s: NULL function", __thisfunc__);
+		sprintf(error_msg, "%s: NULL function %s", "%s", funcname);
+		Host_Error(error_msg, __thisfunc__);
 	}
 
 	f = &pr_functions[fnum];

--- a/engine/hexen2/server/host.c
+++ b/engine/hexen2/server/host.c
@@ -396,7 +396,7 @@ void SV_DropClient (qboolean crash)
 		// this will set the body to a dead frame, among other things
 			saveSelf = *sv_globals.self;
 			*sv_globals.self = EDICT_TO_PROG(host_client->edict);
-			PR_ExecuteProgram (*sv_globals.ClientDisconnect);
+			PR_ExecuteProgram (*sv_globals.ClientDisconnect, "ClientDisconnect");
 			*sv_globals.self = saveSelf;
 		}
 

--- a/engine/hexen2/server/host_cmd.c
+++ b/engine/hexen2/server/host_cmd.c
@@ -859,7 +859,7 @@ static void RestoreClients (int ClientsMode)
 			*sv_globals.time = sv.time;
 			*sv_globals.self = EDICT_TO_PROG(ent);
 			G_FLOAT(OFS_PARM0) = time_diff;
-			PR_ExecuteProgram (*sv_globals.ClientReEnter);
+			PR_ExecuteProgram (*sv_globals.ClientReEnter, "ClientReEnter");
 		}
 	}
 
@@ -1170,7 +1170,7 @@ static void Host_Class_f (void)
 
 	// Change the weapon model used
 	*sv_globals.self = EDICT_TO_PROG(host_client->edict);
-	PR_ExecuteProgram (*sv_globals.ClassChangeWeapon);
+	PR_ExecuteProgram (*sv_globals.ClassChangeWeapon, "ClassChangeWeapon");
 
 // send notification to all clients
 	MSG_WriteByte (&sv.reliable_datagram, svc_updateclass);
@@ -1381,7 +1381,7 @@ static void Host_Kill_f (void)
 
 	*sv_globals.time = sv.time;
 	*sv_globals.self = EDICT_TO_PROG(sv_player);
-	PR_ExecuteProgram (*sv_globals.ClientKill);
+	PR_ExecuteProgram (*sv_globals.ClientKill, "ClientKill");
 }
 
 
@@ -1497,12 +1497,12 @@ static void Host_Spawn_f (void)
 			// call the spawn function
 			*sv_globals.time = sv.time;
 			*sv_globals.self = EDICT_TO_PROG(sv_player);
-			PR_ExecuteProgram (*sv_globals.ClientConnect);
+			PR_ExecuteProgram (*sv_globals.ClientConnect, "ClientConnect");
 
 			if ((Sys_DoubleTime() - NET_QSocketGetTime(host_client->netconnection)) <= sv.time)
 				Sys_Printf ("%s entered the game\n", host_client->name);
 
-			PR_ExecuteProgram (*sv_globals.PutClientInServer);
+			PR_ExecuteProgram (*sv_globals.PutClientInServer, "PutClientInServer");
 		}
 	}
 

--- a/engine/hexen2/sv_main.c
+++ b/engine/hexen2/sv_main.c
@@ -491,10 +491,10 @@ static void SV_SendServerinfo (client_t *client)
 			{
 				MSG_WriteString(&client->message, *s);
 				MSG_WriteShort(&client->message, sv.models[i]->ex_flags);
-				MSG_WriteFloat(&client->message, sv.models[i]->glow_color[0]);
-				MSG_WriteFloat(&client->message, sv.models[i]->glow_color[1]);
-				MSG_WriteFloat(&client->message, sv.models[i]->glow_color[2]);
-				MSG_WriteFloat(&client->message, sv.models[i]->glow_color[3]);
+				MSG_WriteFloat(&client->message, sv.models[i]->glow_settings[COLOR_R]);
+				MSG_WriteFloat(&client->message, sv.models[i]->glow_settings[COLOR_G]);
+				MSG_WriteFloat(&client->message, sv.models[i]->glow_settings[COLOR_B]);
+				MSG_WriteFloat(&client->message, sv.models[i]->glow_settings[COLOR_A]);
 			}
 			#endif
 			i++;

--- a/engine/hexen2/world.c
+++ b/engine/hexen2/world.c
@@ -395,7 +395,7 @@ void SV_TouchLinks(edict_t *ent)
 		*sv_globals.self = EDICT_TO_PROG(touch);
 		*sv_globals.other = EDICT_TO_PROG(ent);
 		*sv_globals.time = sv.time;
-		PR_ExecuteProgram(touch->v.touch);
+		PR_ExecuteProgram(touch->v.touch, "touch");
 
 		*sv_globals.self = old_self;
 		*sv_globals.other = old_other;


### PR DESCRIPTION
New function **PimpModel** to decorate models with cool client-side effects previously hard coded for certain models only.

Previously, only very specific hard coded models were allowed to cast light around (namely projectiles) or have a nice colored glow (like mana or torches). There were also all kinds of cool client effects (mainly trails for projectiles) triggerable through mdl flags only.
Now it's possible to add such effects to any model without having to give it a special hard coded name or fiddle with its flags in QME (whose latest version anyway doesn't give access to them anymore). Just a line of code in HexenC and that's it. 🙂

Supported features:
* RGBA color used for glow and/or dynamically cast light
* Offset vector to neatly position the glow origin from the model origin (notably useful for torches)
* Glow radius
* Light style (normal, pulsating, flickering, etc.) used for glow and/or dynamically cast light
* Dynamically cast light radius

To test the game engine edit, here is the tailored new **misc_modelpimp** entity :

```
@PointClass base(Appearflags, Targetname) color(255 170 255) model ({"path": model}) = misc_modelpimp : "Model properties"
[
	model(string) : "Model to pimp"
	spawnflags(flags) =
	[
		1: "Spin" : 0
		2: "Float" : 0
		4: "Glow orb" : 0
		8: "Cast light" : 0
	]
	flags(flags) =
	[
		1: "Rocket smoke trail" : 0
		2: "Grenade smoke trail" : 0
		4: "Gib long blood trail" : 0
		8: "Rotate" : 0
		16: "Scrag double green trail" : 0
		32: "Zombie gib short blood trail" : 0
		64: "Hellknight orange split trail" : 0
		128: "Vore purple trail" : 0
		256: "Fireball" : 0
		512: "Ice trail" : 0
		1024: "Mipmap" : 0
		2048: "Ink spit" : 0
		4096: "Transparent sprite" : 0
		8192: "Vertical spray" : 0
		16384: "Holey (fence) texture" : 0
		32768: "Translucent" : 0
		65536: "Always facing" : 0
		131072: "Bottom & top trail" : 0
		262144: "Slow staff move" : 0
		524288: "Blue/white magic drip" : 0
		1048576: "Bone shards drip" : 0
		2097152: "Scarab dust" : 0
		4194304: "Acid ball" : 0
		8388608: "Blood rain" : 0
		16777216: "Far mipmap" : 0
	]
	glow_color(string) : "Color for the glow and/or illumination"
	abslight(integer)  : "Glow alpha transparency" : 0.75
	view_ofs(string)   : "Glow offset relatively to model origin (x y z)" : "0 0 0"
	health(integer)    : "Glow radius" : 20
	max_health(integer): "Cast light radius" : 200
	wait(integer)      : "Refresh rate" : 0.5
	style(choices) : "Style (32-63 for groups)" : 0 =
	[
		0 : "Normal"
		1 : "Soft flicker"
		6 : "Faster flicker"

		4 : "Low falloff"

		5 : "Pulse"
		2 : "Slow pulse in & out"
		11 : "Quick pulse in & out"

		3 : "Erratic pulse & flicker A"
		7 : "Erratic pulse & flicker B"
		8 : "Erratic pulse & flicker C"
		9 : "Slow blink"
		10 : "Fluorescent flicker"
		
		12 : "Custom style 1"
		13 : "Custom style 2"
		14 : "Custom style 3"
		15 : "Custom style 4"
		16 : "Custom style 5"
		17 : "Custom style 6"
		18 : "Custom style 7"
		19 : "Custom style 8"
		20 : "Custom style 9"
		21 : "Custom style 10"
		22 : "Custom style 11"
		23 : "Custom style 12"
		24 : "Custom style 13"
		
		25 : "MLS_FULLBRIGHT"
		26 : "MLS_POWERMODE"
		27 : "MLS_TORCH"
		28 : "MLS_FIREFLICKER"
		29 : "MLS_CRYSTALGOLEM"
	]
]
```
An its code :
```
/*QUAKED misc_modelpimp by Inky (11/2021)
An entity able to pimp the properties of a model (like rotation, glow, dynamic light, etc.)
flags	ignore the hard coded flags in the mdl file and use those instead
		Caution : the value set in flags is ignored if the "Showcase flags" mode is active because of a targetname set
		          if so the flags value is handled by code automatically and each call to .use
				  applies a different flag value for flags testing purpose
*/
string FlagFriendlyNames[25] =
{
	"_Rocket smoke trail",
	"_Grenade smoke trail",
	"_Gib long blood trail",
	"_Rotate",
	"_Scrag double green trail",
	"_Zombie gib short blood trail",
	"_Hellknight orange split trail",
	"_Vore purple trail",
	"_Fireball",
	"_Ice trail",
	"_Mipmap",
	"_Ink spit",
	"_Transparent sprite",
	"_Vertical spray",
	"_Holey (fence) texture",
	"_Translucent",
	"_Always facing player",
	"_Bottom & top trail",
	"_Slow staff move",
	"_Blue/white magic drip",
	"_Bone shards drip",
	"_Scarab dust",
	"_Acid ball",
	"_Blood rain",
	"_Far mipmap"
};

float modelpimp_showcase()
{
	//Advance the flags for the next call
	if(self.flags == 16777216)
	{
		self.walkframe = 0;
		self.flags = 1; //We've come full circle, back to the beginning
	}
	else
	{
		self.walkframe = self.walkframe + 1;
		if(self.flags == 0) self.flags = 1; else self.flags = self.flags * 2; //Next value 
	}
	entity player = find (world, classname, "player");
	centerprint(player,FlagFriendlyNames[self.walkframe]);

	return pimpmodel(self, self.glow_color);
}

void modelpimp_think ()
{
	pimpmodel(self, self.glow_color);
	
	//Do it again later (a small delay is mandatory when (re)loading a map; trying to pimp the model right away would come too early and fail)
	self.nextthink = time + self.wait;
}

void() misc_modelpimp =
{
	precache_model(self.model);
	setmodel(self, self.model);
	self.effects(+)EF_NODRAW;
	
	if(!self.wait) self.wait = 0.5;
	
	if(self.targetname)
	{
		self.use = modelpimp_showcase;
		self.walkframe = -1;
		self.flags = 0;
	}
	
	self.think = modelpimp_think;
	self.nextthink = time + self.wait;
}
```

Unrelated to what's above but also included in this PR:
* PR_ExecuteProgram now taking an additional string parameter (the guilty function's name) to make error messages more helpful
* SV_Physics_None made more robust against corner case notably caused by new liquid trains
* SV_PushMove now supporting liquid trains (like raising water or lava) by not pushing things up but flooding them instead