### PR TITLE
Added definition required for custom client effects + support for custom start map

### DIFF
--- a/engine/h2shared/model.h
+++ b/engine/h2shared/model.h
@@ -378,6 +378,24 @@ typedef enum {mod_brush, mod_sprite, mod_alias} modtype_t;
 
 #define	EF_MIP_MAP_FAR		(1 << 24)	/* Set per frame, this model will use the far mip map	*/
 
+#define	EF_SPIN				(1 << 4)	/* Inky: Rotate without floating upside down */
+#define	EF_FLOAT			(1 << 5)	/* Inky: Float upside down without rotating */
+#define	EF_GLOW				(1 << 6)	/* Inky: Feature a custom glowing orb around the model, override the various XF_*GLOW presets */
+#define	EF_ILLUMINATE		(1 << 7)	/* Inky: Cast light dynamically around */
+
+   // slots for qmodel_t->glow_settings
+#define	GLOW_SETTINGS_COUNT 10
+#define	COLOR_R 0
+#define	COLOR_G 1
+#define	COLOR_B 2
+#define	COLOR_A 3
+#define	ORB_OFFSET_X 4
+#define	ORB_OFFSET_Y 5
+#define	ORB_OFFSET_Z 6
+#define	ORB_RADIUS 7
+#define	LIGHT_STYLE 8
+#define	LIGHT_RADIUS 9
+
 typedef struct qmodel_s
 {
 	char		name[MAX_QPATH];
@@ -447,6 +465,7 @@ typedef struct qmodel_s
 //
 // additional model data
 //
+	float		glow_settings[GLOW_SETTINGS_COUNT];
 	cache_user_t	cache;		// only access through Mod_Extradata
 } qmodel_t;
 

--- a/engine/h2shared/sv_model.h
+++ b/engine/h2shared/sv_model.h
@@ -172,6 +172,24 @@ typedef struct
 #define	EF_LIGHT			0x00000040
 #define	EF_NODRAW			0x00000080
 
+#define	EF_SPIN				(1 << 4)	/* Inky: Rotate without floating upside down */
+#define	EF_FLOAT			(1 << 5)	/* Inky: Float upside down without rotating */
+#define	EF_GLOW				(1 << 6)	/* Inky: Feature a custom glowing orb around the model, override the various XF_*GLOW presets */
+#define	EF_ILLUMINATE		(1 << 7)	/* Inky: Cast light dynamically around */
+
+// slots for qmodel_t->glow_settings
+#define	GLOW_SETTINGS_COUNT 10
+#define	COLOR_R 0
+#define	COLOR_G 1
+#define	COLOR_B 2
+#define	COLOR_A 3
+#define	ORB_OFFSET_X 4
+#define	ORB_OFFSET_Y 5
+#define	ORB_OFFSET_Z 6
+#define	ORB_RADIUS 7
+#define	LIGHT_STYLE 8
+#define	LIGHT_RADIUS 9
+
 #ifdef H2W
 /* The only difference between Raven's hw-0.15 binary release and the
  * later HexenC source release is the EF_BRIGHTFIELD and EF_ONFIRE values:
@@ -260,6 +278,11 @@ typedef struct qmodel_s
 	byte		*visdata;
 	byte		*lightdata;
 	char		*entities;
+
+	//
+	// additional model data
+	//
+	float		glow_settings[GLOW_SETTINGS_COUNT];
 } qmodel_t;
 
 // values for qmodel_t->needload

--- a/engine/hexen2/keys.c
+++ b/engine/hexen2/keys.c
@@ -1000,7 +1000,18 @@ void Key_Event (int key, qboolean down)
 
 	if (cl.intermission == 12 && down)
 	{
-		Cbuf_AddText ("map keep1\n");
+		//Launch the new mission (on a custom map if so specificied in the command line)
+		int i = COM_CheckParm("-startnew");
+		if (i && i < com_argc - 1)
+		{
+			Cbuf_AddText("map ");
+			Cbuf_AddText(com_argv[i + 1]);
+			Cbuf_AddText("\n");
+		}
+		else
+		{
+			Cbuf_AddText("map keep1\n");
+		}
 	}
 
 // if not a consolekey, send to the interpreter no matter what mode is

--- a/engine/hexen2/menu.c
+++ b/engine/hexen2/menu.c
@@ -785,7 +785,20 @@ static void M_Difficulty_Key (int key)
 			return;
 		}
 		Cbuf_AddText ("wait\n"); /* make m_none to really work */
-		Cbuf_AddText ("map demo1\n");
+
+		//Launch the old mission (on a custom map if so specificied in the command line)
+		int i = COM_CheckParm("-startold");
+		if (i && i < com_argc - 1)
+		{
+			Cbuf_AddText("map ");
+			Cbuf_AddText(com_argv[i + 1]);
+			Cbuf_AddText("\n");
+		}
+		else
+		{
+			Cbuf_AddText("map demo1\n");
+		}
+
 		break;
 	default:
 		Key_SetDest (key_game);


### PR DESCRIPTION
About the definitions lacking for the Linux compilation I'm totally blind since I can't compile locally anyway.
So I added random declarations. Hope it helps...?

The support for custom map start is a new feature related to Issue #91.